### PR TITLE
Feature class item

### DIFF
--- a/ClassItem.java
+++ b/ClassItem.java
@@ -47,7 +47,7 @@ public class ClassItem
     //check that the oldClassItemName exists in the classItemList
     //check that the newClassItemName is available to use
 
-    public static void renameClassItem(final Map<String, ClassItem> classItemList, final String newClassItemName, final String oldClassItemName){
+    public static String renameClassItem(final Map<String, ClassItem> classItemList, final String newClassItemName, final String oldClassItemName){
         if(classItemList == null){
             throw new IllegalArgumentException("classItemList cannot be null");
         }
@@ -67,13 +67,14 @@ public class ClassItem
                 //sets the classItem Object that is stored in the value associated with the Map for the key oldClassItemName to be newClassItemName
                 String oldName = ((ClassItem) classItemList.get(oldClassItemName)).getClassItemName();
                 ((ClassItem) classItemList.get(oldClassItemName)).setClassItemName(newClassItemName);
-                System.out.println(oldName + " class renamed to \"" + newClassItemName + "\"" );
+                return oldName + " class renamed to \"" + newClassItemName + "\"";
            }else{
-                System.out.println(newClassItemName + " is already in use.");
+                //displayed if newClassItemName is already a key in the HashMap
+                return newClassItemName + " is already in use.";
            }
         }else{ 
-            System.out.println(oldClassItemName+ " does not exist.");
-        //if either of the checks fail, an error message is displayed from their respective method.
+            //displayed when oldClassItemName is not in the HashMap
+            return oldClassItemName+ " does not exist.";
         }
     }
 

--- a/ClassItem.java
+++ b/ClassItem.java
@@ -65,9 +65,12 @@ public class ClassItem
 
             if(!classItemList.containsKey(newClassItemName.toLowerCase().trim())){
                 //sets the classItem Object that is stored in the value associated with the Map for the key oldClassItemName to be newClassItemName
+                // gets the old class name from map
                 String oldName = ((ClassItem) classItemList.get(oldClassItemName)).getClassItemName();
+                // sets the new class name without updating the key in the map
                 ((ClassItem) classItemList.get(oldClassItemName)).setClassItemName(newClassItemName);
-                classItemList.put(newClassItemName.toLowerCase().trim(), classItemList.remove("oldClassItemName"));
+                //ClassItem temp = new ClassItem(newClassItemName);
+                classItemList.put(newClassItemName.toLowerCase().trim(), classItemList.remove(oldClassItemName));
                 return oldName + " class renamed to \"" + newClassItemName + "\"";
            }else{
                 //displayed if newClassItemName is already a key in the HashMap

--- a/ClassItem.java
+++ b/ClassItem.java
@@ -63,10 +63,11 @@ public class ClassItem
         //checks that the old name to be changed exists, and that the name is not a duplicate.
         if(classItemList.containsKey(oldClassItemName)){
 
-            if(!classItemList.containsKey(newClassItemName)){
+            if(!classItemList.containsKey(newClassItemName.toLowerCase().trim())){
                 //sets the classItem Object that is stored in the value associated with the Map for the key oldClassItemName to be newClassItemName
                 String oldName = ((ClassItem) classItemList.get(oldClassItemName)).getClassItemName();
                 ((ClassItem) classItemList.get(oldClassItemName)).setClassItemName(newClassItemName);
+                classItemList.put(newClassItemName.toLowerCase().trim(), classItemList.remove("oldClassItemName"));
                 return oldName + " class renamed to \"" + newClassItemName + "\"";
            }else{
                 //displayed if newClassItemName is already a key in the HashMap
@@ -133,7 +134,7 @@ public class ClassItem
 	}
 
 	//trim any leading or trailing whitespace to ensure valid input
-	methodName = methodName.strip();
+	methodName = methodName.trim();
 	    
         //check if the method name already exists in the class
         if(methodItems.containsKey(methodName))
@@ -162,7 +163,7 @@ public class ClassItem
 	}
 	    
 	//trim any leading or trailing whitespace to ensure valid input
-	methodName = methodName.strip();
+	methodName = methodName.trim();
 	    
         //check if the method name is a valid key
         if(!methodItems.containsKey(methodName))

--- a/ClassItem.java
+++ b/ClassItem.java
@@ -47,7 +47,7 @@ public class ClassItem
     //check that the oldClassItemName exists in the classItemList
     //check that the newClassItemName is available to use
 
-    public static String renameClassItem(final Map<String, ClassItem> classItemList, final String newClassItemName, final String oldClassItemName){
+    public static String renameClassItem(final Map<String, ClassItem> classItemList, final String newClassItemName, final String oldClassItemName, final Map<String, RelationshipItem> relationships){
         if(classItemList == null){
             throw new IllegalArgumentException("classItemList cannot be null");
         }
@@ -71,6 +71,25 @@ public class ClassItem
                 ((ClassItem) classItemList.get(oldClassItemName)).setClassItemName(newClassItemName);
                 //ClassItem temp = new ClassItem(newClassItemName);
                 classItemList.put(newClassItemName.toLowerCase().trim(), classItemList.remove(oldClassItemName));
+                // update the key in the relationship map only, the classname is already updated because
+                // relationship stores the class object, not the name
+
+                for (Map.Entry<String, RelationshipItem> entry : relationships.entrySet()) {
+                    String[] split = entry.getKey().split("_");
+                    String source = split[0];
+                    String destination = split[1];
+                    if (source.equals(oldName)){
+                        RelationshipItem temp = relationships.get(entry.getKey());
+                        relationships.remove(entry.getKey());
+                        relationships.put(newClassItemName + "_" + destination, temp);
+                    }
+                    else {
+                        RelationshipItem temp = relationships.get(entry.getKey());
+                        relationships.remove(entry.getKey());
+                        relationships.put(source + "_" + newClassItemName, temp);
+                    }
+                }
+
                 return oldName + " class renamed to \"" + newClassItemName + "\"";
            }else{
                 //displayed if newClassItemName is already a key in the HashMap

--- a/Main.java
+++ b/Main.java
@@ -69,7 +69,7 @@ public class Main
 				String oldName = scanner.nextLine();
 				System.out.println("Input new name for " + oldName);
 				String newName = scanner.nextLine();
-				System.out.println(ClassItem.renameClassItem(classItems, newName, oldName));
+				System.out.println(ClassItem.renameClassItem(classItems, newName, oldName, relationshipItems));
 				break;
 			case "8":	//Exit
 				ui.Exit();

--- a/Main.java
+++ b/Main.java
@@ -69,7 +69,7 @@ public class Main
 				String oldName = scanner.nextLine();
 				System.out.println("Input new name for " + oldName);
 				String newName = scanner.nextLine();
-				ClassItem.renameClassItem(classItems, newName, oldName);
+				System.out.println(ClassItem.renameClassItem(classItems, newName, oldName));
 				break;
 			case "8":	//Exit
 				ui.Exit();

--- a/RelationshipItem.java
+++ b/RelationshipItem.java
@@ -137,7 +137,7 @@ public class RelationshipItem
     public String toString(){
 
         //the ClassItem objects have a getName() method that returns the name of the class
-        return this.source.getClassItemName() + "has a relationship with " + this.destination.getClassItemName();
+        return this.source.getClassItemName() + " has a relationship with " + this.destination.getClassItemName();
     }
 
 


### PR DESCRIPTION
## classItem

`renameClassItem`
> returns string instead of void to match code standards
> fixed functionality to update the key in the HashMap to match the new name after renameClassItem function is used to rename a Class.

## main

`run`
> fix switch statement for remove a class to fit with changing removeClassItem to return a string rather than void.