### PR TITLE
153 bug renamingretyping fields and parameters both have bugs

### DIFF
--- a/uml/src/main/java/com/unhandledexceptions/Model/MethodItem.java
+++ b/uml/src/main/java/com/unhandledexceptions/Model/MethodItem.java
@@ -180,7 +180,7 @@ public class MethodItem implements UMLObject {
 			return "good";
 		} else {
 			// methodItem does not contain a method with that name.
-			return "RENAMEParameter: " + oldParamName + " does not exist.";
+			return "Parameter: " + oldParamName + " does not exist.";
 		}
 	}
 
@@ -191,15 +191,13 @@ public class MethodItem implements UMLObject {
 		}
 		newParamType = newParamType.trim();
 
-		System.out.println(methodItem.getParameters().keySet());
-
 		if (methodItem.getParameters().containsKey(paramName)) {
 
 			methodItem.getParameter(paramName).setType(newParamType);
 
 			return "good";
 		} else {
-			return "RETYPEParameter: " + paramName + " does not exist.";
+			return "Parameter: " + paramName + " does not exist.";
 		}
 	}
 

--- a/uml/src/main/java/com/unhandledexceptions/Model/ParameterItem.java
+++ b/uml/src/main/java/com/unhandledexceptions/Model/ParameterItem.java
@@ -32,7 +32,7 @@ public class ParameterItem implements UMLObject {
     } // blank constructor for IO serialization
 
     // constructor
-    public ParameterItem(String type, String parameterName) {
+    public ParameterItem(String parameterName, String type) {
         if (parameterName == null || parameterName.isBlank()) {
             throw new IllegalArgumentException("Type and Parameter name cannot be null or blank - constructor");
         }
@@ -81,7 +81,6 @@ public class ParameterItem implements UMLObject {
         this.type = type;
     }
 
-    // placeholder toString
     @Override
     public String toString() {
         return this.type + " " + this.parameterName;

--- a/uml/src/main/java/com/unhandledexceptions/View/ClassBox.java
+++ b/uml/src/main/java/com/unhandledexceptions/View/ClassBox.java
@@ -80,6 +80,10 @@ public class ClassBox extends StackPane
 
     public void Update()
     {
+        //rename class: NameClicked, renameClassLabel
+        //delete class: createDeleteButton
+
+        //get class item object
         ClassItem classItem = baseController.getData().getClassItems().get(className.toLowerCase().trim());
         if (classItem == null)
         {
@@ -340,6 +344,7 @@ public class ClassBox extends StackPane
         }
         return null;
     }
+    
 
     // method to rename a class box label
     public void renameClassLabel(String newName) {

--- a/uml/src/main/java/com/unhandledexceptions/View/ClassBox.java
+++ b/uml/src/main/java/com/unhandledexceptions/View/ClassBox.java
@@ -59,14 +59,18 @@ public class ClassBox extends StackPane
     AnchorPane anchorPane;
     TitledPane methodsPane;
     TitledPane fieldsPane;
+    private ClassItem classItem; // ClassItem object associated with the ClassBox to add listeners
 
     public ClassBox(AnchorPane anchorPane, BaseController baseController, String classNameIn, double boxWidth,
-     double boxHeight, Rectangle[] ranchors)
+     double boxHeight, Rectangle[] ranchors, ClassItem classItem)
     {
         this.anchorPane = anchorPane;
         this.baseController = baseController;
         this.className = classNameIn;
         this.ranchors = ranchors;
+        this.classItem = classItem;
+        this.classItem.addPropertyChangeListener(this);
+        // createClassBox(classNameIn, boxWidth, boxHeight);
     }
 
     public void Remove(AnchorPane anchorPane)
@@ -76,7 +80,7 @@ public class ClassBox extends StackPane
 
     public void Update()
     {
-        ClassItem classItem = baseController.getData().getClassItems().get(className);
+        ClassItem classItem = baseController.getData().getClassItems().get(className.toLowerCase().trim());
         if (classItem == null)
         {
             //remove any relationlines

--- a/uml/src/main/java/com/unhandledexceptions/View/ClassBox.java
+++ b/uml/src/main/java/com/unhandledexceptions/View/ClassBox.java
@@ -538,8 +538,8 @@ public class ClassBox extends StackPane implements PropertyChangeListener
             Pair<String, String> userInput = createInputDialogs("Parameters");
 
             if(userInput != null){
-                String type = (userInput.getKey() != null) ? null : userInput.getKey().toLowerCase();
-                String name = (userInput.getValue() != null) ? null : userInput.getValue().toLowerCase();
+                String type = (userInput.getKey() == null) ? null : userInput.getKey().toLowerCase();
+                String name = (userInput.getValue() == null) ? null : userInput.getValue().toLowerCase();
                 //String typeName = type + " " + name;    
                 String result = baseController.AddParameterListener(className, methodName, type, name);   
                 if (!(result == "good"))
@@ -632,18 +632,20 @@ public class ClassBox extends StackPane implements PropertyChangeListener
     private void UpdateParam(String methodName, String newParamName, String oldParamName, String newParamType) {
         // Validate input for new field name and type
         if (newParamName.isBlank() || newParamName.isBlank()) {
-            ClassBox.showError("Field name and type cannot be empty.");
+            ClassBox.showError("Parameter name and type cannot be empty.");
             return;
         }
     
         String resultName = null;
-         // Attempt to change the field type
+
+        // Attempt to retype the param
+         String resultType = baseController.RetypeParameterListener(className, methodName, oldParamName, newParamType);
+
+        //Attempt to rename the param
         if(!oldParamName.equals(newParamName)){
             resultName = baseController.RenameParameterListener(className, methodName,newParamName, oldParamName);
         }
-        // Attempt to rename the field
-        String resultType = baseController.RetypeParameterListener(className, methodName, oldParamName, newParamType);
-        //String resultType = baseController.RetypeFieldListener(className, newParamName, newParamType);
+    
     
         // Check the results for both operations
         if (("good".equals(resultName) || resultName == null ) && "good".equals(resultType)) {

--- a/uml/src/main/java/com/unhandledexceptions/View/ClassBox.java
+++ b/uml/src/main/java/com/unhandledexceptions/View/ClassBox.java
@@ -474,14 +474,19 @@ public class ClassBox extends StackPane
                     String[] parts = selectedItem.split(" "); // Assuming the format is "name - type"
                     if (parts.length == 2) {
                         String oldParamType = parts[0].trim();
+                        String newParamType = oldParamType;
                         String oldParamName = parts[1].trim();
-
+                        String newParamName = oldParamName;
                         // Create input dialog to get new name and type
                         Pair<String, String> userInput = createInputDialogs("Field");
 
-                        if (userInput != null) {
-                            String newParamName = userInput.getValue().toLowerCase();
-                            String newParamType = userInput.getKey().toLowerCase();
+                        if (userInput != null) {    //user inputs some data
+                            if(userInput.getValue() != null){   //changing param name
+                                newParamName = userInput.getValue().toLowerCase();
+                            }
+                            if(userInput.getKey() != null){     //changing param type             
+                                newParamType = userInput.getKey().toLowerCase();
+                            }
 
                             // Call UpdateField to update the model
                             UpdateParam(methodName, newParamName, oldParamName, newParamType);
@@ -761,9 +766,9 @@ public class ClassBox extends StackPane
         firstInputField.textProperty().addListener((observable, oldValue, newValue) -> {
             addButton.setDisable(firstInputField.getText().isEmpty()|| secondInputField.getText().isEmpty());
         });
-        secondInputField.textProperty().addListener((observable, oldValue, newValue) -> {
-            addButton.setDisable(firstInputField.getText().isEmpty()|| secondInputField.getText().isEmpty());
-        });
+        // secondInputField.textProperty().addListener((observable, oldValue, newValue) -> {
+        //     addButton.setDisable(firstInputField.getText().isEmpty()|| secondInputField.getText().isEmpty());
+        // });
 
         // Convert the result to a pair of strings when the Add button is clicked
         dialog.setResultConverter(dialogButton -> {

--- a/uml/src/main/java/com/unhandledexceptions/View/ClassBox.java
+++ b/uml/src/main/java/com/unhandledexceptions/View/ClassBox.java
@@ -67,7 +67,6 @@ public class ClassBox extends StackPane
         this.baseController = baseController;
         this.className = classNameIn;
         this.ranchors = ranchors;
-        // createClassBox(classNameIn, boxWidth, boxHeight);
     }
 
     public void Remove(AnchorPane anchorPane)
@@ -77,10 +76,6 @@ public class ClassBox extends StackPane
 
     public void Update()
     {
-        //rename class: NameClicked, renameClassLabel
-        //delete class: createDeleteButton
-
-        //get me
         ClassItem classItem = baseController.getData().getClassItems().get(className);
         if (classItem == null)
         {
@@ -601,14 +596,16 @@ public class ClassBox extends StackPane
                     // Split the selected item to get old name and type
                     String[] parts = selectedItem.split(" "); // Assuming the format is "name - type"
                     if (parts.length == 2) {
+                        String oldTypeName = parts[0].trim();
                         String oldFieldName = parts[1].trim();
 
                         // Create input dialog to get new name and type
                         Pair<String, String> userInput = createInputDialogs("Field");
 
                         if (userInput != null) {
-                            String newFieldName = userInput.getValue().toLowerCase();
-                            String newFieldType = userInput.getKey().toLowerCase();
+                            // String type = firstInputField.getText().isEmpty() ? null : firstInputField.getText();
+                            String newFieldName = (userInput.getValue() == null) ? oldFieldName : userInput.getValue();
+                            String newFieldType = (userInput.getKey() == null) ? oldTypeName : userInput.getKey();
 
                             // Call UpdateField to update the model
                             UpdateField(oldFieldName, newFieldName, newFieldType);
@@ -640,14 +637,16 @@ public class ClassBox extends StackPane
             ClassBox.showError("Field name and type cannot be empty.");
             return;
         }
-    
+        String resultName = null;
         // Attempt to rename the field
-        String resultName = baseController.RenameFieldListener(className, oldFieldName, newFieldName);
+        if(!oldFieldName.equals(newFieldName)){
+            resultName = baseController.RenameFieldListener(className, oldFieldName, newFieldName);
+        }
         // Attempt to change the field type
         String resultType = baseController.RetypeFieldListener(className, newFieldName, newFieldType);
     
         // Check the results for both operations
-        if ("good".equals(resultName) && "good".equals(resultType)) {
+        if (("good".equals(resultName) || resultName == null ) && "good".equals(resultType)) {
             Update(); // Update the UI if both updates succeeded
         } else {
             // Show the appropriate error message based on which operation failed
@@ -724,10 +723,10 @@ public class ClassBox extends StackPane
     }
 
     
-
+    /**/
     public Pair<String, String> createInputDialogs(String promptName) {
         Dialog<Pair<String, String>> dialog = new Dialog<>();
-        dialog.setTitle("Add promptName");
+        dialog.setTitle("Add: " + promptName);
         dialog.setHeaderText("Enter the " + promptName.toLowerCase() + " and name.");
 
         // Set the button types
@@ -764,16 +763,18 @@ public class ClassBox extends StackPane
 
         // Add listeners to fields to enable Add button when both fields have text
         firstInputField.textProperty().addListener((observable, oldValue, newValue) -> {
-            addButton.setDisable(firstInputField.getText().isEmpty()|| secondInputField.getText().isEmpty());
+            addButton.setDisable(firstInputField.getText().isEmpty()&& secondInputField.getText().isEmpty());
         });
-        // secondInputField.textProperty().addListener((observable, oldValue, newValue) -> {
-        //     addButton.setDisable(firstInputField.getText().isEmpty()|| secondInputField.getText().isEmpty());
-        // });
+        secondInputField.textProperty().addListener((observable, oldValue, newValue) -> {
+            addButton.setDisable(firstInputField.getText().isEmpty()&& secondInputField.getText().isEmpty());
+        });
 
         // Convert the result to a pair of strings when the Add button is clicked
         dialog.setResultConverter(dialogButton -> {
             if (dialogButton == addButtonType) {
-                return new Pair<>(firstInputField.getText(), secondInputField.getText());
+                String type = firstInputField.getText().isEmpty() ? null : firstInputField.getText();
+                String name = secondInputField.getText().isEmpty() ? null : secondInputField.getText();
+                return new Pair<>(type, name);
             }
             return null;
         });

--- a/uml/src/main/java/com/unhandledexceptions/View/ClassBox.java
+++ b/uml/src/main/java/com/unhandledexceptions/View/ClassBox.java
@@ -305,7 +305,6 @@ public class ClassBox extends StackPane
         return deleteButton;
     }
 
-    // ================================================================================================================================================================
     // method to create a dialog box for user input of class name
     public static String classNameDialog() {
         // creates a dialog box for user input
@@ -338,7 +337,6 @@ public class ClassBox extends StackPane
         return null;
     }
 
-    // ================================================================================================================================================================
     // method to rename a class box label
     public void renameClassLabel(String newName) {
         // gets the label from the classBox object
@@ -349,12 +347,14 @@ public class ClassBox extends StackPane
             nameLabel.setText(newName);
     }
 
+    //User for the Update() Method
     public void clearMethods()
     {
         ListView<TitledPane> methodsList = (ListView<TitledPane>) methodsPane.getContent();
         methodsList.getItems().clear();
     }
 
+    //Used for the Update() Method
     public void addMethod(String methodName, String methodType, ObservableList<String> params)
     {
         TitledPane newMethodPane = createNewMethod(methodName, methodType);  //create new box with list for params
@@ -364,6 +364,30 @@ public class ClassBox extends StackPane
         methodParamList.setItems(params);
     }
 
+    /**
+     * Creates and returns a {@link TitledPane} for managing methods. The pane includes
+     * a list of methods represented by individual {@code TitledPane} objects and a button
+     * for adding new methods.
+     *
+     * <p>The {@code TitledPane} contains:
+     * <ul>
+     *   <li>A title bar with a "Methods" label and an "Add Method" button.</li>
+     *   <li>A {@link ListView} to display individual method panes.</li>
+     * </ul>
+     * </p>
+     *
+     * <p>Key Features:
+     * <ul>
+     *   <li>Allows the addition of new methods via an input dialog. The user inputs the method's 
+     *       name and type, and the model is updated using {@code baseController.AddMethodListener()}.</li>
+     *   <li>Displays error messages if invalid input is provided or the addition fails.</li>
+     *   <li>Applies custom styling to the pane and its components using predefined CSS classes.</li>
+     *   <li>Sets up spacing and alignment for the title bar's label and button.</li>
+     * </ul>
+     * </p>
+     *
+     * @return the configured {@code TitledPane} for managing methods.
+     */
     public TitledPane createMethodPane() {
         // Create TitledPane for methods
         methodsPane = new TitledPane();
@@ -416,6 +440,35 @@ public class ClassBox extends StackPane
         return methodsPane;
     }
 
+    /**
+     * Creates a new {@link TitledPane} to represent a method with its type, name, 
+     * and a list of parameters. The pane provides functionality to add new parameters 
+     * and edit the method's name, type, or parameters via double-click actions.
+     *
+     * <p>The {@code TitledPane} includes:
+     * <ul>
+     *   <li>A title bar with the method type, name, and an "Add Parameter" button.</li>
+     *   <li>A {@link ListView} to display the method's parameters.</li>
+     *   <li>Double-click functionality for renaming the method's type, name, or parameters.</li>
+     * </ul>
+     * </p>
+     *
+     * <p>Key Features:
+     * <ul>
+     *   <li>Allows the addition of new parameters using an input dialog. Updates the model via 
+     *       {@code baseController.AddParameterListener()}.</li>
+     *   <li>Supports double-click actions to edit existing parameters by invoking the 
+     *       {@code UpdateParam()} method.</li>
+     *   <li>Allows editing of the method's name and type via double-click events, calling 
+     *       {@code MethodNameClicked()} and {@code MethodTypeClicked()}, respectively.</li>
+     *   <li>Validates all input and displays errors for invalid or failed updates.</li>
+     * </ul>
+     * </p>
+     *
+     * @param methodName the name of the method.
+     * @param methodType the return type of the method.
+     * @return the configured {@code TitledPane} for the method.
+     */
     private TitledPane createNewMethod(String methodName, String methodType) {
         TitledPane singleMethodPane = new TitledPane();
         singleMethodPane.setExpanded(true);
@@ -430,7 +483,6 @@ public class ClassBox extends StackPane
         ObservableList<String> params = FXCollections.observableArrayList();
         methodParamList.setItems(params);
 
-        // TODO: fix issue where setting content here causes the list to be able to be
         // expanded without items in it. set after an item is added?
         singleMethodPane.setContent(methodParamList);
 
@@ -514,6 +566,28 @@ public class ClassBox extends StackPane
         return singleMethodPane;
     }
 
+    /**
+     * Updates a parameter of a method in the model by renaming it and/or changing its type.
+     * Validates the input and updates the UI if the operation succeeds. Displays error
+     * messages if validation fails or an update operation is unsuccessful.
+     *
+     * <p>Key Features:
+     * <ul>
+     *   <li>Renames the parameter using {@code baseController.RenameParameterListener()} if 
+     *       the new parameter name is different from the old one.</li>
+     *   <li>Changes the parameter type using {@code baseController.RetypeParameterListener()}.</li>
+     *   <li>Updates the UI by calling {@code Update()} if both operations are successful.</li>
+     *   <li>Displays an appropriate error message if either operation fails.</li>
+     *   <li>Ensures that neither the new parameter name nor type is blank before attempting 
+     *       any updates.</li>
+     * </ul>
+     * </p>
+     *
+     * @param methodName   the name of the method to which the parameter belongs.
+     * @param newParamName the new name for the parameter.
+     * @param oldParamName the current name of the parameter.
+     * @param newParamType the new type for the parameter.
+     */
     private void UpdateParam(String methodName, String newParamName, String oldParamName, String newParamType) {
         // Validate input for new field name and type
         if (newParamName.isBlank() || newParamName.isBlank()) {
@@ -552,6 +626,27 @@ public class ClassBox extends StackPane
         fieldsList.setItems(fields);
     }
 
+    /**
+     * Creates and returns a {@link TitledPane} that contains a list of fields with functionality
+     * to add new fields and rename existing ones. The pane includes a label, an add button, and a 
+     * {@link ListView} to display field names. It supports double-clicking a field to rename it 
+     * and updating the model accordingly.
+     *
+     * <p>The {@code TitledPane} is initially collapsed, styled with custom CSS classes, and 
+     * restricted to a maximum height of 150 pixels. Fields can be added via an input dialog, and 
+     * each field is displayed as a combination of its type and name.</p>
+     *
+     * <p>Key Features:
+     * <ul>
+     *   <li>Add new fields using a "+" button. Prompts the user to input a type and name.</li>
+     *   <li>Double-click an existing field to rename it via an input dialog.</li>
+     *   <li>Updates the model using the {@code baseController.AddFieldListener()} method.</li>
+     *   <li>Displays errors if invalid input is provided or if the addition/update fails.</li>
+     * </ul>
+     * </p>
+     *
+     * @return the configured {@code TitledPane} for managing fields.
+     */
     public TitledPane createFieldPane() {
         fieldsPane = new TitledPane();
         fieldsPane.setExpanded(false);
@@ -632,6 +727,26 @@ public class ClassBox extends StackPane
         return fieldsPane;
     }
     
+    /**
+     * Updates a field in the model by renaming it and/or changing its type. 
+     * Validates input for the new field name and type, and performs updates 
+     * through the appropriate listener methods in the controller.
+     *
+     * <p>The method performs the following actions:
+     * <ul>
+     *   <li>Checks that the new field name and type are not blank.</li>
+     *   <li>Attempts to rename the field using {@code baseController.RenameFieldListener()} 
+     *       if the new name is different from the old name.</li>
+     *   <li>Attempts to change the field type using {@code baseController.RetypeFieldListener()}.</li>
+     *   <li>Displays error messages if either operation fails, using {@code ClassBox.showError()}.</li>
+     *   <li>Updates the UI by calling {@code Update()} if both operations succeed.</li>
+     * </ul>
+     * </p>
+     *
+     * @param oldFieldName the current name of the field to be updated.
+     * @param newFieldName the new name for the field. Must not be blank.
+     * @param newFieldType the new type for the field. Must not be blank.
+     */
     private void UpdateField(String oldFieldName, String newFieldName, String newFieldType) {
         // Validate input for new field name and type
         if (newFieldName.isBlank() || newFieldType.isBlank()) {
@@ -751,9 +866,6 @@ public class ClassBox extends StackPane
         grid.setHgap(10);
         grid.setVgap(10);
         grid.setPadding(new Insets(20, 150, 10, 10));
-
-        // ComboBox<String> typeComboBox = new ComboBox<>();
-        // setupComboBox(typeComboBox);
 
         //Text for type input
         TextField firstInputField = new TextField();

--- a/uml/src/test/java/BaseControllerTests.java
+++ b/uml/src/test/java/BaseControllerTests.java
@@ -73,7 +73,7 @@ public class BaseControllerTests {
     // ensure that the relationship was added to the data object
     assertTrue(data.getRelationshipItems().containsKey("testclass1_testclass2"));
     // ensure the relationship type is correct
-    assertEquals("aggregation", data.getRelationshipItems().get("testclass1_testclass2").getType());
+    assertEquals("Aggregation", data.getRelationshipItems().get("testclass1_testclass2").getType());
   }
 
   // Test removing a relationship

--- a/uml/src/test/java/DataTests.java
+++ b/uml/src/test/java/DataTests.java
@@ -46,7 +46,7 @@ public class DataTests
     result = newData.Load(newData.getCurrentPath());
 
     //test if load returned a positive string
-    assertEquals(result, "successfully loaded " + newData.getCurrentPath(), "result should equal successfully loaded " + newData.getCurrentPath());
+    assertEquals(result, "good");
 
     //test the new data is equal to the original data
     assertEquals(origData, newData, "Loaded data should match original data.");
@@ -70,7 +70,7 @@ public class DataTests
     // load data from file
     res = data2.Load("test123.json");
     // make sure loaded successfully 
-    assertEquals("successfully loaded test123.json", res);
+    assertEquals("good", res);
     // make sure class item loaded properly
     assertEquals(data2.getClassItems().size(), 1);
     // delete the test file

--- a/uml/src/test/java/RelationshipItemTests.java
+++ b/uml/src/test/java/RelationshipItemTests.java
@@ -30,7 +30,7 @@ public class RelationshipItemTests {
     // ensures that the map has the correct key
     assertTrue(relationshipMap.containsKey("class1_class2"));
     // ensures that the map has the correct relationship object
-    assertEquals("class1 ---- composition ----> class2", relationshipMap.get("class1_class2").toString());
+    assertEquals("class1 ---- Composition ----> class2", relationshipMap.get("class1_class2").toString());
   }
 
   // test that a relationship is not created if the source class does not exist


### PR DESCRIPTION
Changed constructor for Parameter item, as it was swapped compared to similar constructors.

Added some documentation for ClassBox createTitlePane methods

Rename/Retype fields/params now accepts only 1 of the 2 at a time.

Refactored the createInputDialog method.

Pull from develop caused some tests to fail, as the tests weren't changed to match the punctuation/format changes made to some methods return strings.

